### PR TITLE
Feat / Update chromecast SDK (iOS + Android)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -34,7 +34,7 @@
       <meta-data android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME" android:value="acidhax.cordova.chromecast.CastOptionsProvider" />
     </config-file>
 
-    <framework src="com.google.android.gms:play-services-cast-framework:21.0.1" />
+    <framework src="com.google.android.gms:play-services-cast-framework:21.3.0" />
 
     <source-file src="src/android/CastOptionsProvider.java" target-dir="src/acidhax/cordova/chromecast" />
     <source-file src="src/android/Chromecast.java" target-dir="src/acidhax/cordova/chromecast" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -56,7 +56,7 @@
         <source url="https://cdn.cocoapods.org/"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="google-cast-sdk" spec="~> 4.5.2" />
+        <pod name="google-cast-sdk" spec="~> 4.6.1" />
       </pods>
     </podspec>
 


### PR DESCRIPTION
Updated Chromecast SDK for iOS and Android.

Since version `4.7.0` on iOS causes an “Unexpected failure“ build error in XCode I reduced it to the latest working version (`4.6.1`). The cause of this error is unknown.

This version doesn't fix any particular issues we currently experience.

See the official changelog for changes: https://developers.google.com/cast/docs/release-notes