### PR TITLE
Remove sharedPreferences and NSUserDefaults for storing the app id

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,34 @@ The "*Description" key strings will be used when asking the user for permission 
 </platform>
 ```
 
+1. In AppDelegate.m (or AppDelegate.swift) add
+
+```
+#import <GoogleCast/GoogleCast.h>
+```
+
+```swift
+import GoogleCast
+```
+
+and insert the following in the `application:didFinishLaunchingWithOptions` method, ideally at the beginning (or right after Flipper initialization):
+
+```
+NSString *receiverAppID = kGCKDefaultMediaReceiverApplicationID; // or @"ABCD1234"
+GCKDiscoveryCriteria *criteria = [[GCKDiscoveryCriteria alloc] initWithApplicationID:receiverAppID];
+GCKCastOptions* options = [[GCKCastOptions alloc] initWithDiscoveryCriteria:criteria];
+[GCKCastContext setSharedInstanceWithOptions:options];
+```
+
+```swift
+let receiverAppID = kGCKDefaultMediaReceiverApplicationID // or "ABCD1234"
+let criteria = GCKDiscoveryCriteria(applicationID: receiverAppID)
+let options = GCKCastOptions(discoveryCriteria: criteria)
+GCKCastContext.setSharedInstanceWith(options)
+```
+
+If using a custom receiver, replace kGCKDefaultMediaReceiverApplicationID with your receiver app id.
+
 ## Chromecast Icon Assets  
 [chromecast-assets.zip](https://github.com/jellyfin/cordova-plugin-chromecast/wiki/chromecast-assets.zip)
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,37 @@
 
 # Installation
 
-> Use a commit hash to prevent dependency hijacking
+To install this fork, you can use the full GitHub URL with commit hash. Always try using a commit hash to prevent 
+installing malicious code.
 
 ```
 cordova plugin add https://github.com/Videodock/cordova-plugin-chromecast.git#d82f07e26a53df6322043403e4dc98bb2eeb4e39
 ```
 
-If you have trouble installing the plugin or running the project for iOS, from `/platforms/ios/` try running:  
+## Android
+
+Add the following metadata to your AndroidManifest.xml inside the `<application>` tag.
+
+Replace `_APP_ID_` with your receiver application id.
+
+```xml
+<manifest>
+  <application>
+    <activity>
+      ...
+    </activity>
+    <meta-data
+            android:name="com.google.android.gms.cast.framework.RECEIVER_APPLICATION_ID"
+            android:value="_APP_ID_" />
+  </application>
+</manifest>
+```
+
+
+## iOS
+
+If you have trouble installing the plugin or running the project for iOS, from `/platforms/ios/` try running:
+
 ```bash
 sudo gem install cocoapods
 pod repo update
@@ -60,7 +84,7 @@ The "*Description" key strings will be used when asking the user for permission 
 import GoogleCast
 ```
 
-and insert the following in the `application:didFinishLaunchingWithOptions` method, ideally at the beginning (or right after Flipper initialization):
+and insert the following in the `application:didFinishLaunchingWithOptions` method, ideally at the beginning:
 
 ```
 NSString *receiverAppID = kGCKDefaultMediaReceiverApplicationID; // or @"ABCD1234"
@@ -77,6 +101,38 @@ GCKCastContext.setSharedInstanceWith(options)
 ```
 
 If using a custom receiver, replace kGCKDefaultMediaReceiverApplicationID with your receiver app id.
+
+You can also automatically set the receiver ID by parsing the Bonjour Services string. This is useful when you have 
+multiple Info.plist files for different environments. 
+
+```swift
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        initializeCastSender()
+        return true
+    }
+    
+    func initializeCastSender() {
+        if let value = Bundle.init(for: AppDelegate.self).infoDictionary?["NSBonjourServices"] as? [String] {
+            
+            if let rule = value.first(where: { $0.hasSuffix("._googlecast._tcp") }) {
+                let startIndex = rule.index(rule.startIndex, offsetBy: 1)
+                let endIndex = rule.index(rule.startIndex, offsetBy: 9)
+                let receiverAppID = String(rule[startIndex..<endIndex]);
+                
+                let criteria = GCKDiscoveryCriteria(applicationID: receiverAppID)
+                let options = GCKCastOptions(discoveryCriteria: criteria)
+                
+                GCKCastContext.setSharedInstanceWith(options)
+                
+                print("Initialized Cast SDK with appId: \(receiverAppID)")
+            } else {
+                print("Couldn't initialize Cast SDK, NSBonjourServices is defined, but couldn't find _<appId>._googlecast._tcp in the Array");
+            }
+        } else {
+            print("Couldn't initialize Cast SDK, NSBonjourServices is missing from the Info.plist");
+        }
+    }
+```
 
 ## Chromecast Icon Assets  
 [chromecast-assets.zip](https://github.com/jellyfin/cordova-plugin-chromecast/wiki/chromecast-assets.zip)
@@ -112,6 +168,15 @@ But in **cordova-plugin-chromecast** you do:
 document.addEventListener("deviceready", function () {
     // start using the api!
 });
+```
+
+The `SessionRequest#appId` property is not used to define the receiver app and can be set to an empty string to disable the warning.
+Reason for this is that the Cast SDK can be initialized on app startup. Also, for iOS, the Info.plist must be configured with your receiver ID. This makes it easy to mis align the application ID in the initialization and native config.  
+```js
+var sessionRequest = new chrome.cast.SessionRequest('A11B22C'); // doesn't use A11B22C (triggers console warning)
+var sessionRequest = new chrome.cast.SessionRequest(''); // disables console warning
+
+var apiConfig = new chrome.cast.ApiConfig(sessionRequest);
 ```
 
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,7 @@
     <config-file target="AndroidManifest.xml" parent="/manifest/application">
       <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version" />
       <meta-data android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME" android:value="acidhax.cordova.chromecast.CastOptionsProvider" />
+      <meta-data android:name="com.google.android.gms.cast.framework.RECEIVER_APPLICATION_ID" android:value="CC1AD845" />
     </config-file>
 
     <framework src="com.google.android.gms:play-services-cast-framework:21.3.0" />

--- a/src/android/CastOptionsProvider.java
+++ b/src/android/CastOptionsProvider.java
@@ -2,31 +2,35 @@ package acidhax.cordova.chromecast;
 
 import java.util.List;
 
+import com.google.android.gms.cast.CastMediaControlIntent;
 import com.google.android.gms.cast.framework.CastOptions;
 import com.google.android.gms.cast.framework.OptionsProvider;
 import com.google.android.gms.cast.framework.SessionProvider;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 
 public final class CastOptionsProvider implements OptionsProvider {
 
-    /** The app id. */
-    private static String appId;
+    protected String getReceiverApplicationId(Context context) {
+        String appId = null;
+        try {
+            PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+            appId = packageInfo.applicationInfo.metaData.getString("com.google.android.gms.cast.framework.RECEIVER_APPLICATION_ID");
+        } catch (PackageManager.NameNotFoundException e) {
+        }
 
-    /**
-     * Sets the app ID.
-     * @param applicationId appId
-     */
-    public static void setAppId(String applicationId) {
-        appId = applicationId;
+        return appId != null ? appId : CastMediaControlIntent.DEFAULT_MEDIA_RECEIVER_APPLICATION_ID;
     }
 
     @Override
     public CastOptions getCastOptions(Context context) {
         return new CastOptions.Builder()
-                .setReceiverApplicationId(appId)
+                .setReceiverApplicationId(getReceiverApplicationId(context))
                 .build();
     }
+
     @Override
     public List<SessionProvider> getAdditionalSessionProviders(Context context) {
         return null;

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -171,14 +171,13 @@ public final class Chromecast extends CordovaPlugin {
     /**
      * Initialize all of the MediaRouter stuff with the AppId.
      * For now, ignore the autoJoinPolicy and defaultActionPolicy; those will come later
-     * @param appId               The appId we're going to use for ALL session requests
      * @param autoJoinPolicy      tab_and_origin_scoped | origin_scoped | page_scoped
      * @param defaultActionPolicy create_session | cast_this_tab
      * @param callbackContext called with .success or .error depending on the result
      * @return true for cordova
      */
-    public boolean initialize(final String appId, String autoJoinPolicy, String defaultActionPolicy, final CallbackContext callbackContext) {
-        connection.initialize(appId, callbackContext);
+    public boolean initialize(String autoJoinPolicy, String defaultActionPolicy, final CallbackContext callbackContext) {
+        connection.initialize(callbackContext);
         return true;
     }
 

--- a/www/chrome.cast.js
+++ b/www/chrome.cast.js
@@ -544,7 +544,7 @@ var _session;
  * @param  {function} errorCallback
  */
 chrome.cast.initialize = function (apiConfig, successCallback, errorCallback) {
-    execute('initialize', apiConfig.sessionRequest.appId, apiConfig.autoJoinPolicy, apiConfig.defaultActionPolicy, function (err) {
+    execute('initialize', apiConfig.autoJoinPolicy, apiConfig.defaultActionPolicy, function (err) {
         if (!err) {
             // Don't set the listeners config until success
             _initialized = true;

--- a/www/chrome.cast.js
+++ b/www/chrome.cast.js
@@ -544,6 +544,10 @@ var _session;
  * @param  {function} errorCallback
  */
 chrome.cast.initialize = function (apiConfig, successCallback, errorCallback) {
+    if (apiConfig.sessionRequest.appId && 'warn' in window.console) {
+        console.warn('cordova-plugin-chromecast', 'The initialize command doesn\'t respect the `SessionId#appId` (see readme for more information)');
+    }
+
     execute('initialize', apiConfig.autoJoinPolicy, apiConfig.defaultActionPolicy, function (err) {
         if (!err) {
             // Don't set the listeners config until success


### PR DESCRIPTION
This PR updates the app ID configuration because we found some issues due to using NSUserDefaults and SharedPreferences.

Tested on iOS and Android devices