### PR TITLE
Chore / maintenance 2025 q4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "java-checkstyle": "0.1.0"
   },
   "resolutions": {
-    "minimatch/brace-expansion": "1.1.12"
+    "minimatch/brace-expansion": "1.1.12",
+    "js-yaml":"4.1.1"
   }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@
         <source url="https://cdn.cocoapods.org/"/>
       </config>
       <pods use-frameworks="true">
-        <pod name="google-cast-sdk" spec="~> 4.8.3" />
+        <pod name="google-cast-sdk" spec="~> 4.8.4" />
       </pods>
     </podspec>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,7 +35,7 @@
       <meta-data android:name="com.google.android.gms.cast.framework.RECEIVER_APPLICATION_ID" android:value="CC1AD845" />
     </config-file>
 
-    <framework src="com.google.android.gms:play-services-cast-framework:22.1.0" />
+    <framework src="com.google.android.gms:play-services-cast-framework:22.2.0" />
 
     <source-file src="src/android/CastOptionsProvider.java" target-dir="src/acidhax/cordova/chromecast" />
     <source-file src="src/android/Chromecast.java" target-dir="src/acidhax/cordova/chromecast" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,10 +1181,10 @@ java-checkstyle@0.1.0:
     path "^0.12.7"
     yargs "^14.0.0"
 
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+js-yaml@4.1.1, js-yaml@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
# Maintenance 2025 q4

I've updated the iOS and Android SDKs to the latest version. See the release details for:

- [Android SDK 22.2.0](https://developers.google.com/cast/docs/release-notes#october-20,-2025)
- [iOS SDK 4.8.4](https://developers.google.com/cast/docs/release-notes#oct-7,-2025)

js-yaml has been patched to fix https://github.com/advisories/GHSA-mh29-5h37-fv8m